### PR TITLE
chore: switch to official crystallang/crystal image

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -37,7 +37,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     container:
-      image: 84codes/crystal:latest-debian-12
+      image: crystallang/crystal:1.19.1
     steps:
       - uses: actions/checkout@v5
       - name: Install dependencies

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           mkdir -p build
           # Use Crystal container to build static binary
-          docker run --rm -v $(pwd):/eoyc -w /eoyc --entrypoint="" 84codes/crystal:latest-debian-12 sh -c "
+          docker run --rm -v $(pwd):/eoyc -w /eoyc --entrypoint="" crystallang/crystal:1.19.1 sh -c "
             apt-get update && apt-get install -y libyaml-dev ca-certificates git curl &&
             shards install --production &&
             mkdir -p build &&

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -26,7 +26,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Build eoyc Binary
         run: |
-          docker run --rm --platform linux/${{ matrix.arch }} -v $(pwd):/eoyc -w /eoyc --entrypoint="" 84codes/crystal:latest-debian-12 sh -c "
+          docker run --rm --platform linux/${{ matrix.arch }} -v $(pwd):/eoyc -w /eoyc --entrypoint="" crystallang/crystal:1.19.1 sh -c "
             apt-get update && apt-get install -y libyaml-dev ca-certificates git curl &&
             shards install --production &&
             /usr/bin/crystal build src/eoyc.cr -o eoyc --release --no-debug --static


### PR DESCRIPTION
## Summary
- Crystal now provides [official Linux ARM64 builds](https://crystal-lang.org/2026/04/07/official-linux-arm64-builds/), so we can drop the 84codes images that were previously needed for multi-arch coverage.
- Replaced `84codes/crystal:latest-debian-12` with `crystallang/crystal:1.19.1` in the CI test container, release-binary, and release-deb workflows.

## Test plan
- [x] Static linux/arm64 build succeeds locally with the new image (produces statically linked aarch64 ELF)
- [ ] CI green