### PR TITLE
ci(homebrew): fix Ruby interpolation in formula test block

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -23,7 +23,7 @@ jobs:
             system "shards install"
             system "shards build --release --no-debug --production"
             bin.install "bin/eoyc"
-          test: system "{bin}/eoyc", "-v"
+          test: system "#{bin}/eoyc", "-v"
           update_readme_table: true
           skip_commit: false
           skip_checksum: true


### PR DESCRIPTION
## Summary
- The current homebrew-releaser config emits a formula whose `test` block reads `system "{bin}/eoyc", "-v"` — a literal path, which breaks `brew test` and `brew audit`.
- Switched to `#{bin}` so Homebrew interpolates the formula's bin path.
- Next published release will regenerate `Formula/eoyc.rb` correctly.

Same fix as hahwul/hwaro#518 — caught while sweeping siblings for the same pattern.

## Test plan
- [ ] After next release, verify the published formula contains `system "#{bin}/eoyc", "-v"` and `brew test eoyc` succeeds