### PR TITLE
Harden CLI validation and output handling

### DIFF
--- a/spec/cli_spec.cr
+++ b/spec/cli_spec.cr
@@ -1,0 +1,60 @@
+require "spec"
+
+private def run_cli(args : Array(String), input : String = "")
+  stdout = IO::Memory.new
+  stderr = IO::Memory.new
+  status = Process.run(
+    "crystal",
+    ["run", "src/eoyc.cr", "--"] + args,
+    input: IO::Memory.new(input),
+    output: stdout,
+    error: stderr
+  )
+
+  {status: status.exit_code, stdout: stdout.to_s, stderr: stderr.to_s}
+end
+
+describe "eoyc CLI" do
+  it "fails for unknown encoders" do
+    result = run_cli(["-e", "missing"], "hello\n")
+
+    result[:status].should eq(1)
+    result[:stdout].should eq("")
+    result[:stderr].should contain("ERROR: unknown encoder: missing")
+  end
+
+  it "fails cleanly for invalid regex patterns" do
+    result = run_cli(["-r", "[", "-e", "base64"], "hello\n")
+
+    result[:status].should eq(1)
+    result[:stdout].should eq("")
+    result[:stderr].should contain("ERROR: invalid regex '['")
+  end
+
+  it "does not create the output file when regex validation fails" do
+    path = File.join(Dir.tempdir, "eoyc-invalid-regex-#{Process.pid}.txt")
+
+    begin
+      result = run_cli(["-r", "[", "-e", "base64", "-o", path], "hello\n")
+
+      result[:status].should eq(1)
+      File.exists?(path).should be_false
+    ensure
+      File.delete(path) if File.exists?(path)
+    end
+  end
+
+  it "writes JSON output to the requested output file" do
+    path = File.join(Dir.tempdir, "eoyc-json-#{Process.pid}.json")
+
+    begin
+      result = run_cli(["-e", "base64", "--json", "-o", path], "hello\n")
+
+      result[:status].should eq(0)
+      result[:stdout].should eq("")
+      File.read(path).strip.should eq(%({"input":["hello"],"encoders":["base64"],"output":["aGVsbG8="]}))
+    ensure
+      File.delete(path) if File.exists?(path)
+    end
+  end
+end

--- a/spec/encoders/metadata_spec.cr
+++ b/spec/encoders/metadata_spec.cr
@@ -139,6 +139,20 @@ describe "Encoders.describe_json" do
   end
 end
 
+describe "Encoders.unknown_names" do
+  it "returns unknown encoder names" do
+    Encoders.unknown_names(["base64", "missing", "md5"]).should eq(["missing"])
+  end
+
+  it "normalizes whitespace and ignores empty names" do
+    Encoders.unknown_names([" base64 ", "", "  "]).should be_empty
+  end
+
+  it "deduplicates unknown names" do
+    Encoders.unknown_names(["missing", "missing"]).should eq(["missing"])
+  end
+end
+
 describe "Encoders.categories_json" do
   it "returns valid JSON grouped by category" do
     json_str = Encoders.categories_json

--- a/src/encoders/core.cr
+++ b/src/encoders/core.cr
@@ -691,6 +691,14 @@ module Encoders
     @@name_to_spec[name.downcase]?
   end
 
+  # Return chain names that do not resolve to a registered encoder.
+  def unknown_names(names : Array(String)) : Array(String)
+    names.map(&.strip)
+      .reject(&.empty?)
+      .uniq!
+      .reject { |name| find(name) }
+  end
+
   # Produce lines suited for help output.
   def help_lines : Array(String)
     specs.map do |spec|
@@ -728,7 +736,7 @@ module Encoders
   # JSON: describe a single encoder by name.
   def describe_json(name : String) : String?
     spec = find(name)
-    return nil unless spec
+    return unless spec
     JSON.build do |json|
       spec.to_json(json)
     end

--- a/src/eoyc.cr
+++ b/src/eoyc.cr
@@ -47,7 +47,7 @@ OptionParser.parse do |parser|
   parser.on "-s STRING", "--string=STRING", "Your choice string" { |var| choice = var }
   parser.on "-r REGEX", "--regex=REGEX", "Your choice regex pattern" { |var| regex = var }
   parser.on "-e ENCODERS", "--encoders=ENCODERS", "Encoders chain [char: >|,]" do |var|
-    origin = var.split(/>|\||,/)
+    origin = var.split(/>|\||,/).map(&.strip).reject(&.empty?)
     encoders = origin.reverse
   end
   parser.on "-o PATH", "--output=PATH", "Output file" { |var| output = var }
@@ -89,7 +89,7 @@ end
 
 # Handle AI-friendly discovery commands (no stdin needed)
 if show_capabilities
-  puts(JSON.build { |json|
+  puts(JSON.build do |json|
     json.object do
       json.field "tool", "eoyc"
       json.field "version", Eoyc::VERSION
@@ -133,7 +133,7 @@ if show_capabilities
         end
       end
     end
-  })
+  end)
   exit
 end
 
@@ -155,7 +155,7 @@ end
 
 if search_keyword != ""
   results = Encoders.search(search_keyword)
-  puts(JSON.build { |json|
+  puts(JSON.build do |json|
     json.object do
       json.field "query", search_keyword
       json.field "count", results.size
@@ -165,7 +165,7 @@ if search_keyword != ""
         end
       end
     end
-  })
+  end)
   exit
 end
 
@@ -174,16 +174,37 @@ if show_categories
   exit
 end
 
-# Main processing loop
-io = output != "" ? File.open(output, "w") : STDOUT
-begin
-  compiled_regex = regex.empty? ? "" : Regex.new(regex)
+unknown_encoders = Encoders.unknown_names(encoders)
+unless unknown_encoders.empty?
+  STDERR.puts "ERROR: unknown encoder#{unknown_encoders.size == 1 ? "" : "s"}: #{unknown_encoders.join(", ")}"
+  STDERR.puts "Run `eoyc --list` to see available encoders."
+  exit(1)
+end
 
+compiled_regex = begin
+  regex.empty? ? "" : Regex.new(regex)
+rescue ex : ArgumentError
+  STDERR.puts "ERROR: invalid regex '#{regex}': #{ex.message}"
+  exit(1)
+end
+
+# Main processing loop
+io = if output != ""
+       begin
+         File.open(output, "w")
+       rescue ex
+         STDERR.puts "ERROR: cannot open output file '#{output}': #{ex.message}"
+         exit(1)
+       end
+     else
+       STDOUT
+     end
+begin
   if json_mode
     lines = [] of String
     STDIN.each_line { |line| lines << line }
 
-    puts(JSON.build { |json|
+    io.puts(JSON.build do |json|
       json.object do
         json.field "input", lines
         json.field "encoders", encoders.reverse
@@ -227,7 +248,7 @@ begin
           end
         end
       end
-    })
+    end)
   else
     STDIN.each_line do |line|
       io.puts Eoyc.process_line(line, choice, compiled_regex, encoders)


### PR DESCRIPTION
## Summary
- validate encoder chains and fail clearly for unknown encoder names
- handle invalid regex and output file open errors without stack traces
- write JSON mode output through the selected output stream, including -o files
- add CLI integration coverage for validation and JSON output behavior

## Tests
- crystal tool format --check
- crystal spec
- crystal run lib/ameba/bin/ameba.cr --
- shards build