### PR TITLE
ci(homebrew): ship a prebuilt-binary formula via the tap

### DIFF
--- a/.github/homebrew/eoyc.rb.tmpl
+++ b/.github/homebrew/eoyc.rb.tmpl
@@ -1,0 +1,46 @@
+# typed: strict
+# frozen_string_literal: true
+
+# This file is rendered by eoyc's release pipeline (.github/workflows/publish-homebrew.yml).
+# DO NOT EDIT by hand.
+class Eoyc < Formula
+  desc "Chainable string encoding/decoding CLI (Endless Options, Your Chain)"
+  homepage "https://github.com/hahwul/eoyc"
+  version "__VERSION__"
+  license "MIT"
+
+  on_macos do
+    # macOS binaries are dynamically linked; openssl@3 is the only non-system
+    # dependency (enforced by an otool guard in release-binary.yml).
+    depends_on "openssl@3"
+
+    on_arm do
+      url "https://github.com/hahwul/eoyc/releases/download/v__VERSION__/eoyc-v__VERSION__-osx-arm64"
+      sha256 "__SHA_OSX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/hahwul/eoyc/releases/download/v__VERSION__/eoyc-v__VERSION__-osx-x86_64"
+      sha256 "__SHA_OSX_X86_64__"
+    end
+  end
+
+  on_linux do
+    # Linux release binaries are statically linked, so they are self-contained.
+    on_arm do
+      url "https://github.com/hahwul/eoyc/releases/download/v__VERSION__/eoyc-v__VERSION__-linux-arm64"
+      sha256 "__SHA_LINUX_ARM64__"
+    end
+    on_intel do
+      url "https://github.com/hahwul/eoyc/releases/download/v__VERSION__/eoyc-v__VERSION__-linux-x86_64"
+      sha256 "__SHA_LINUX_X86_64__"
+    end
+  end
+
+  def install
+    bin.install Dir["eoyc-v__VERSION__-*"].first => "eoyc"
+  end
+
+  test do
+    system "#{bin}/eoyc", "-v"
+  end
+end

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,30 +1,104 @@
 ---
 name: Homebrew tap Publish
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.3.0)"
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
+permissions:
+  contents: read
 jobs:
-  homebrew-releaser:
+  publish-formula:
+    name: Publish prebuilt formula to tap
+    # Run after a release-triggered binary build succeeds, or on manual
+    # dispatch. The prebuilt formula needs the release binaries to exist first.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
     runs-on: ubuntu-latest
-    name: homebrew-releaser
     steps:
-      - name: Release Eoyc to Homebrew tap
-        uses: Justintime50/homebrew-releaser@v1
+      - name: Checkout source (formula template)
+        uses: actions/checkout@v6
         with:
-          homebrew_owner: hahwul
-          homebrew_tap: homebrew-eoyc
-          formula_folder: Formula
-          github_token: ${{ secrets.EOYC_PUBLISH_TOKEN }}
-          commit_owner: hahwul
-          commit_email: hahwul@gmail.com
-          depends_on: |
-            "crystal"
-          install: |
-            system "shards install"
-            system "shards build --release --no-debug --production"
-            bin.install "bin/eoyc"
-          test: system "#{bin}/eoyc", "-v"
-          update_readme_table: true
-          skip_commit: false
-          skip_checksum: true
-          debug: false
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
+
+      - name: Resolve version
+        id: ver
+        # Pass event data via env (never interpolate ${{ }} straight into the
+        # script body) so a crafted tag/branch name can't inject shell.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RAW="$DISPATCH_VERSION"
+          else
+            RAW="$RUN_BRANCH"
+          fi
+          # Strip leading 'v' if present
+          VERSION="${RAW#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - name: Download release binaries and compute checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          # Linux binaries are static; macOS binaries link only openssl@3.
+          for asset in osx-arm64 osx-x86_64 linux-arm64 linux-x86_64; do
+            gh release download "v$V" --repo hahwul/eoyc \
+              --pattern "eoyc-v$V-$asset" --output "eoyc-v$V-$asset"
+          done
+          {
+            echo "SHA_OSX_ARM64=$(sha256sum "eoyc-v$V-osx-arm64" | awk '{print $1}')"
+            echo "SHA_OSX_X86_64=$(sha256sum "eoyc-v$V-osx-x86_64" | awk '{print $1}')"
+            echo "SHA_LINUX_ARM64=$(sha256sum "eoyc-v$V-linux-arm64" | awk '{print $1}')"
+            echo "SHA_LINUX_X86_64=$(sha256sum "eoyc-v$V-linux-x86_64" | awk '{print $1}')"
+          } >> "$GITHUB_ENV"
+
+      - name: Render formula
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          mkdir -p out
+          sed \
+            -e "s|__VERSION__|$V|g" \
+            -e "s|__SHA_OSX_ARM64__|$SHA_OSX_ARM64|g" \
+            -e "s|__SHA_OSX_X86_64__|$SHA_OSX_X86_64|g" \
+            -e "s|__SHA_LINUX_ARM64__|$SHA_LINUX_ARM64|g" \
+            -e "s|__SHA_LINUX_X86_64__|$SHA_LINUX_X86_64|g" \
+            .github/homebrew/eoyc.rb.tmpl > out/eoyc.rb
+          echo "----- rendered formula -----"
+          cat out/eoyc.rb
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v6
+        with:
+          repository: hahwul/homebrew-eoyc
+          token: ${{ secrets.EOYC_PUBLISH_TOKEN }}
+          path: tap
+
+      - name: Commit and push formula
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          mkdir -p tap/Formula
+          cp out/eoyc.rb tap/Formula/eoyc.rb
+          cd tap
+          git config user.name "hahwul"
+          git config user.email "hahwul@gmail.com"
+          git add Formula/eoyc.rb
+          if git diff --cached --quiet; then
+            echo "Formula unchanged; nothing to publish."
+            exit 0
+          fi
+          git commit -m "eoyc $V"
+          git push

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Crystal
@@ -47,9 +47,30 @@ jobs:
         name: Build binary (macOS)
         run: |
           mkdir -p build
+          # Pin PKG_CONFIG_PATH to openssl@3 so the binary links the current
+          # OpenSSL instead of an EOL openssl@1.1, which would fail to launch on
+          # a clean machine (dyld: libssl.1.1.dylib not found). openssl@3 is the
+          # only Homebrew dylib the binary needs; it is declared in the formula.
+          brew install openssl@3
+          export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          BIN="build/eoyc-${GITHUB_REF_SLUG}-osx-${ARCH}"
           crystal build src/eoyc.cr \
-            -o build/eoyc-${GITHUB_REF_SLUG}-osx-${ARCH} \
+            -o "$BIN" \
             --no-debug --release
+          echo "== otool -L $BIN ==" && otool -L "$BIN"
+          # Guard 1: never ship a macOS binary linked against EOL openssl@1.1.
+          if otool -L "$BIN" | grep -q 'openssl@1.1'; then
+            echo "::error::macOS binary still links EOL openssl@1.1"; exit 1
+          fi
+          # Guard 2: openssl@3 must be the ONLY Homebrew dynamic dep, else the
+          # formula's depends_on list is out of date.
+          EXTRA="$(otool -L "$BIN" \
+            | grep -oE '/(opt/homebrew|usr/local)/(opt|Cellar)/[^/]+' \
+            | grep -v 'openssl@3' | sort -u || true)"
+          if [ -n "$EXTRA" ]; then
+            echo "::error::unexpected non-openssl@3 Homebrew deps (update formula depends_on):"
+            echo "$EXTRA"; exit 1
+          fi
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## What
`brew install hahwul/eoyc/eoyc` currently **compiles eoyc from source** (tap formula from `Justintime50/homebrew-releaser`). This switches the tap to a **prebuilt-binary** formula, mirroring [hwaro](https://github.com/hahwul/hwaro).

## How it works
1. `release-binary.yml` builds 4 prebuilt binaries (`eoyc-v<ver>-{osx,linux}-{arm64,x86_64}`) → GitHub Release.
2. `publish-homebrew.yml` (now a render+push job) downloads them, computes `sha256`, renders `.github/homebrew/eoyc.rb.tmpl`, and commits `Formula/eoyc.rb` to `hahwul/homebrew-eoyc`.

## Changes
- add `.github/homebrew/eoyc.rb.tmpl` — macOS `depends_on "openssl@3"`; Linux is static and self-contained.
- rewrite `publish-homebrew.yml` → render template + push to tap (replaces the source-build job).
- `release-binary.yml`: add the **`macos-15-intel`** runner (`osx-x86_64`); **pin `PKG_CONFIG_PATH` to `openssl@3`** so the macOS binary no longer links **EOL `openssl@1.1`**; add an `otool` guard enforcing `openssl@3` as the only Homebrew dylib.

## Notes
- Takes effect on the **next tagged release**.
- Verified locally: `brew style` clean; deps confirmed via `otool -L` of the real released binary.
