### PR TITLE
ci: align workflows with hwaro, add AUR packaging, raise project quality

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,0 +1,12 @@
+# Ameba configuration for eoyc.
+# Run `just check` (or `crystal run lib/ameba/bin/ameba.cr`) to lint locally.
+
+# Public API docs are covered by the docs site, not inline doc comments.
+Documentation:
+  Enabled: false
+
+# Specs use `.not_nil!` as a test-time assertion; a nil there fails the test
+# loudly, which is the intent.
+Lint/NotNil:
+  Excluded:
+    - spec/**/*.cr

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: hahwul

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           round: false
-          includeBots: true
+          includeBots: false
           noCommit: true
       - uses: peter-evans/create-pull-request@v8.1.1
         with:

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -52,3 +52,12 @@ jobs:
         run: shards install
       - name: Run tests
         run: crystal spec
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crystal-lang/install-crystal@v1
+      - name: Check version consistency
+        # Fails the build if shard.yml, src/eoyc.cr, snap and aur/PKGBUILD
+        # ever drift apart (the drift this PR was created to fix).
+        run: crystal run scripts/version_check.cr

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -3,7 +3,13 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths: ["**/*.cr", shard.yml]
+    paths:
+      - .github/workflows/crystal.yml
+      - shard.yml
+      - shard.lock
+      - "**/*.cr"
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       logLevel:
@@ -15,31 +21,33 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal-version: [1.15.0, 1.16.0, 1.17.0, 1.18.0, 1.20.0]
+        # Matches `crystal: ~> 1.19` in shard.yml.
+        crystal-version: [1.19.0, 1.20.0]
     steps:
-      - uses: actions/checkout@v5
-      - uses: MeilCli/setup-crystal-action@v4
+      - uses: actions/checkout@v6
+      - uses: crystal-lang/install-crystal@v1
         with:
-          crystal_version: ${{ matrix.crystal-version }}
+          crystal: ${{ matrix.crystal-version }}
       - name: Install dependencies
         run: shards install
       - name: Build
         run: shards build
   lint:
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal
     steps:
-      - uses: actions/checkout@v5
-      - name: Crystal Ameba Linter
-        id: crystal-ameba
+      - uses: actions/checkout@v6
+      - name: Run Ameba linter
         uses: crystal-ameba/github-action@master
   tests:
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:1.20
+    strategy:
+      matrix:
+        crystal-version: [1.19.0, 1.20.0]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal-version }}
       - name: Install dependencies
         run: shards install
       - name: Run tests

--- a/.github/workflows/hwaro.yml
+++ b/.github/workflows/hwaro.yml
@@ -4,8 +4,14 @@ name: Hwaro CI/CD
 on:
   push:
     branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/hwaro.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/hwaro.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish-snapcraft.yml
+++ b/.github/workflows/publish-snapcraft.yml
@@ -26,7 +26,8 @@ jobs:
         uses: actions/checkout@v6
       - uses: canonical/action-build@v1
         id: build
-      - uses: snapcore/action-publish@master
+      - if: github.event_name == 'release'
+        uses: snapcore/action-publish@master
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
         with:

--- a/.github/workflows/release-aur.yml
+++ b/.github/workflows/release-aur.yml
@@ -1,0 +1,64 @@
+---
+name: Publish AUR Package
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g., 0.4.0)"
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
+permissions:
+  contents: read
+jobs:
+  publish-aur:
+    # Run after a release-triggered binary build succeeds, or on manual
+    # dispatch. The PKGBUILD points at the release binary, so it must exist.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
+
+      - name: Get Version
+        id: get_version
+        # Pass event data via env (never interpolate ${{ }} straight into the
+        # script body) so a crafted tag/branch name can't inject shell.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RAW="$DISPATCH_VERSION"
+          else
+            RAW="$RUN_BRANCH"
+          fi
+          # Strip leading 'v' if present
+          VERSION="${RAW#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Resolved version: $VERSION"
+
+      - name: Update PKGBUILD version
+        env:
+          V: ${{ env.VERSION }}
+        run: |
+          sed -i "s/^pkgver=.*/pkgver=${V}/" aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+          cat aur/PKGBUILD
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
+        with:
+          pkgname: eoyc
+          pkgbuild: aur/PKGBUILD
+          commit_username: hahwul
+          commit_email: hahwul@gmail.com
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -12,13 +12,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel]
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: ubuntu-24.04-arm
+            platform: linux
+          - os: macos-latest
+            platform: macos
+          - os: macos-15-intel
+            platform: macos
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
       - name: Checkout source code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: shards install
       - name: Inject slug/short variables
@@ -32,18 +40,19 @@ jobs:
           else
             echo "ARCH=unknown" >> $GITHUB_ENV
           fi
-      - if: startsWith(matrix.os, 'ubuntu')
+      - if: matrix.platform == 'linux'
         name: Build binary (Linux)
         run: |
           mkdir -p build
-          # Use Crystal container to build static binary
+          # Build inside the Crystal container and link statically. eoyc does no
+          # networking, so a glibc static binary is safe (no getaddrinfo/NSS path).
           docker run --rm -v $(pwd):/eoyc -w /eoyc --entrypoint="" crystallang/crystal:1.20 sh -c "
             apt-get update && apt-get install -y libyaml-dev ca-certificates git curl &&
             shards install --production &&
             mkdir -p build &&
             /usr/bin/crystal build src/eoyc.cr -o build/eoyc-${GITHUB_REF_SLUG}-linux-${ARCH} --release --no-debug --static
           "
-      - if: startsWith(matrix.os, 'macos')
+      - if: matrix.platform == 'macos'
         name: Build binary (macOS)
         run: |
           mkdir -p build
@@ -72,7 +81,7 @@ jobs:
             echo "$EXTRA"; exit 1
           fi
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-${{ matrix.os }}-${{ env.ARCH }}
           path: build

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -2,35 +2,67 @@
 name: Build and Release .deb Package
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+    inputs:
+      version:
+        description: "Version to build (e.g., 0.4.0)"
+        required: true
+        type: string
+      upload_to_release:
+        description: "Upload .deb to GitHub Release (requires existing tag)"
+        required: false
+        type: boolean
+        default: false
+  workflow_run:
+    workflows: ["Build and Release Binaries"]
+    types: [completed]
 permissions:
   contents: write
 jobs:
   build-deb:
+    # Run after a release-triggered binary build succeeds, or on manual
+    # dispatch. The .deb wraps a prebuilt binary, so the release assets
+    # must already exist.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'release')
     strategy:
+      fail-fast: false
       matrix:
         arch: [amd64, arm64]
     runs-on: ubuntu-latest
     steps:
-      - name: Install Crystal
-        uses: crystal-lang/install-crystal@v1
       - name: Checkout source code
-        uses: actions/checkout@v5
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
       - name: Get Version
         id: get_version
+        # Pass event data via env (never interpolate ${{ }} straight into the
+        # script body) so a crafted tag/branch name can't inject shell.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-      - name: Build eoyc Binary
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            RAW="$DISPATCH_VERSION"
+          else
+            RAW="$RUN_BRANCH"
+          fi
+          # Strip leading 'v' if present
+          VERSION="${RAW#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Resolved version: $VERSION"
+      - name: Download prebuilt binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker run --rm --platform linux/${{ matrix.arch }} -v $(pwd):/eoyc -w /eoyc --entrypoint="" crystallang/crystal:1.20 sh -c "
-            apt-get update && apt-get install -y libyaml-dev ca-certificates git curl &&
-            shards install --production &&
-            /usr/bin/crystal build src/eoyc.cr -o eoyc --release --no-debug --static
-          "
+          ARCH_NAME=${{ matrix.arch == 'amd64' && 'x86_64' || 'arm64' }}
+          gh release download "v${{ env.VERSION }}" --repo hahwul/eoyc \
+            --pattern "eoyc-v${{ env.VERSION }}-linux-${ARCH_NAME}" \
+            --output eoyc
+          chmod +x eoyc
       - name: Create Debian Package Structure
         run: |
           mkdir -p eoyc_${{ env.VERSION }}_${{ matrix.arch }}/DEBIAN
@@ -45,16 +77,23 @@ jobs:
           Package: eoyc
           Version: ${{ env.VERSION }}
           Architecture: ${{ matrix.arch }}
-          maintainer: HAHWUL <hahwul@gmail.com>, KSG <ksg97031@gmail.com>
-          Description: Attack surface detector that identifies endpoints by static analysis
+          Maintainer: HAHWUL <hahwul@gmail.com>, KSG <ksg97031@gmail.com>
+          Description: Endless Options, Your Chain - encode and hash strings with flexible chain operations.
           Depends: libc6 (>= 2.17)
           EOF
       - name: Build .deb Package
         run: |
           dpkg-deb --build eoyc_${{ env.VERSION }}_${{ matrix.arch }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: eoyc_${{ env.VERSION }}_${{ matrix.arch }}.deb
+          path: eoyc_${{ env.VERSION }}_${{ matrix.arch }}.deb
       - name: Upload .deb to Release
+        if: github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.upload_to_release)
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ env.VERSION }}
           files: |
             eoyc_${{ env.VERSION }}_${{ matrix.arch }}.deb
         env:

--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
       # Checkout the repository code
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       # Generate SBOM using hahwul/cyclonedx-cr action
       - name: Generate SBOM
-        uses: hahwul/cyclonedx-cr@v1.0.0
+        uses: hahwul/cyclonedx-cr@v1.0.2
         with:
           shard_file: ./shard.yml # Explicitly map to shard_file
           lock_file: ./shard.lock # Explicitly map to lock_file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,7 +171,7 @@ Use `>`, `|`, or `,` to chain encoders:
 The project includes GitHub Actions workflows:
 - `crystal.yml` - Crystal CI pipeline
 - `contributors.yml` - Contributors update
-- `release-*.yml` - Release automation (binary, deb, sbom)
+- `release-*.yml` - Release automation (binary, deb, sbom, aur)
 - `publish-*.yml` - Package publishing (homebrew, snapcraft)
 
 ## Development Workflow
@@ -191,7 +191,7 @@ just test           # Run tests
 just check          # Check formatting and linting
 just fix            # Auto-format and fix issues
 just version-check  # Verify version is consistent across files
-just version-update # Bump version across shard.yml, src, snap
+just version-update # Bump version across shard.yml, src, snap, aur
 ```
 
 ## Known Limitations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,12 @@ crystal tool format --check
 crystal tool format
 ```
 
-### Linting (if ameba is available)
+### Linting
 ```bash
-ameba
+# Uses the project-local ameba installed by `shards install`
+crystal run lib/ameba/bin/ameba.cr
+# or simply:
+just check
 ```
 
 ## Project Structure
@@ -183,10 +186,12 @@ The project includes GitHub Actions workflows:
 ### Quick Development Commands
 ```bash
 # Using justfile
-just build    # Build the application
-just test     # Run tests
-just check    # Check formatting and linting
-just fix      # Auto-format and fix issues
+just build          # Build the application
+just test           # Run tests
+just check          # Check formatting and linting
+just fix            # Auto-format and fix issues
+just version-check  # Verify version is consistent across files
+just version-update # Bump version across shard.yml, src, snap
 ```
 
 ## Known Limitations
@@ -199,13 +204,13 @@ just fix      # Auto-format and fix issues
 ### Crystal Not Found
 Ensure Crystal is in PATH after installation:
 ```bash
-export PATH=$PWD/crystal-1.17.1-1/bin:$PATH
+export PATH=$PWD/crystal-1.20.0-1/bin:$PATH
 ```
 
 ### Build Failures
 Check Crystal version compatibility:
 ```bash
-crystal --version  # Should be 1.7.3+
+crystal --version  # Should be 1.19+ (shard.yml requires `~> 1.19`)
 ```
 
 ### Test Failures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# CONTRIBUTING
+
+1. Fork it (<https://github.com/hahwul/eoyc/fork>)
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Endless Options, Your Chain
 
 For comprehensive documentation, visit: [https://eoyc.hahwul.com](https://eoyc.hahwul.com)
 
-Or view the documentation locally:
+Or view the documentation locally (the docs site is built with [hwaro](https://github.com/hahwul/hwaro)):
 ```bash
 cd docs
-zola serve
+hwaro serve
 ```
 
 ## Installation

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,15 @@
+# Maintainer: HAHWUL <hahwul@gmail.com>
+pkgname=eoyc
+pkgver=0.4.0
+pkgrel=1
+pkgdesc="Endless Options, Your Chain - chainable string encoding/decoding CLI written in Crystal."
+arch=('x86_64')
+url="https://github.com/hahwul/eoyc"
+license=('MIT')
+source=("eoyc-${pkgver}::https://github.com/hahwul/eoyc/releases/download/v${pkgver}/eoyc-v${pkgver}-linux-x86_64")
+sha256sums=('SKIP')
+
+package() {
+  install -Dm755 "${srcdir}/eoyc-${pkgver}" "${pkgdir}/usr/bin/eoyc"
+  install -Dm644 "${srcdir}/../LICENSE" "${pkgdir}/usr/share/licenses/eoyc/LICENSE"
+}

--- a/justfile
+++ b/justfile
@@ -1,42 +1,59 @@
-# Alias
+# Aliases
 alias b := build
 alias ds := docs-serve
 alias db := docs-build
+alias vc := version-check
+alias vu := version-update
 
-# Default task, lists all available tasks.
+# List available tasks.
 default:
-    @echo "Listing available tasks..."
-    @echo "Aliases: b (build), ds (docs-serve), db (docs-build)"
     @just --list
 
-# Build the application using Crystal Shards.
+# Build the eoyc binary.
+[group('build')]
 build:
-    @echo "Building the application..."
+    shards install
     shards build
 
-# Automatically format code and fix linting issues.
+# Clean build artifacts and dependencies.
+[group('build')]
+clean:
+    rm -rf bin/
+    rm -rf lib/
+
+# Auto-format code and fix lint issues.
+[group('development')]
 fix:
-    @echo "Formatting code and fixing linting issues..."
     crystal tool format
-    ameba --fix
+    crystal run lib/ameba/bin/ameba.cr -- --fix
 
-# Check code formatting and run linter without making changes.
+# Check code format and lint without changes.
+[group('development')]
 check:
-    @echo "Checking code format and running linter..."
     crystal tool format --check
-    ameba
+    crystal run lib/ameba/bin/ameba.cr
 
-# Run all Crystal spec tests.
+# Run all tests.
+[group('development')]
 test:
-    @echo "Running tests..."
     crystal spec
 
-# Serve documentation site locally with Zola.
-docs-serve:
-    @echo "Serving documentation site..."
-    @cd docs && zola serve
+# Check version consistency across all files.
+[group('development')]
+version-check:
+    crystal run scripts/version_check.cr
 
-# Build documentation site with Zola.
+# Update version across all files.
+[group('development')]
+version-update:
+    crystal run scripts/version_update.cr
+
+# Serve the docs site locally (requires hwaro: https://github.com/hahwul/hwaro).
+[group('documents')]
+docs-serve:
+    @cd docs && hwaro serve
+
+# Build the docs site (requires hwaro: https://github.com/hahwul/hwaro).
+[group('documents')]
 docs-build:
-    @echo "Building documentation site..."
-    @cd docs && zola build
+    @cd docs && hwaro build

--- a/scripts/version_check.cr
+++ b/scripts/version_check.cr
@@ -1,0 +1,55 @@
+require "yaml"
+
+# Verifies that the version string is identical across every file that
+# embeds it. Run via `just version-check` (or `crystal run
+# scripts/version_check.cr`) before tagging a release.
+
+# Extract version from shard.yml
+def get_shard_version : String?
+  shard = YAML.parse(File.read("shard.yml"))
+  shard["version"].as_s
+rescue
+  nil
+end
+
+# Extract VERSION from src/eoyc.cr
+def get_eoyc_version : String?
+  content = File.read("src/eoyc.cr")
+  match = content.match(/VERSION\s*=\s*"([^"]+)"/)
+  match ? match[1] : nil
+rescue
+  nil
+end
+
+# Extract version from snap/snapcraft.yaml
+def get_snapcraft_version : String?
+  snapcraft = YAML.parse(File.read("snap/snapcraft.yaml"))
+  snapcraft["version"].as_s
+rescue
+  nil
+end
+
+shard_v = get_shard_version
+eoyc_v = get_eoyc_version
+snapcraft_v = get_snapcraft_version
+
+puts "Shard version:     #{shard_v || "Not found"}"
+puts "Eoyc version:      #{eoyc_v || "Not found"}"
+puts "Snapcraft version: #{snapcraft_v || "Not found"}"
+
+versions = [shard_v, eoyc_v, snapcraft_v].compact
+
+if versions.empty?
+  puts "No versions found!"
+  exit 1
+end
+
+unique_versions = versions.uniq
+
+if unique_versions.size == 1
+  puts "All versions match: #{unique_versions.first}"
+else
+  puts "Versions do not match!"
+  puts "Unique versions found: #{unique_versions.join(", ")}"
+  exit 1
+end

--- a/scripts/version_check.cr
+++ b/scripts/version_check.cr
@@ -29,15 +29,26 @@ rescue
   nil
 end
 
+# Extract pkgver from aur/PKGBUILD
+def get_pkgbuild_version : String?
+  content = File.read("aur/PKGBUILD")
+  match = content.match(/^pkgver=([\d.]+)/m)
+  match ? match[1] : nil
+rescue
+  nil
+end
+
 shard_v = get_shard_version
 eoyc_v = get_eoyc_version
 snapcraft_v = get_snapcraft_version
+pkgbuild_v = get_pkgbuild_version
 
 puts "Shard version:     #{shard_v || "Not found"}"
 puts "Eoyc version:      #{eoyc_v || "Not found"}"
 puts "Snapcraft version: #{snapcraft_v || "Not found"}"
+puts "PKGBUILD version:  #{pkgbuild_v || "Not found"}"
 
-versions = [shard_v, eoyc_v, snapcraft_v].compact
+versions = [shard_v, eoyc_v, snapcraft_v, pkgbuild_v].compact
 
 if versions.empty?
   puts "No versions found!"

--- a/scripts/version_update.cr
+++ b/scripts/version_update.cr
@@ -8,6 +8,7 @@ require "yaml"
 SHARD_FILE     = "shard.yml"
 EOYC_FILE      = "src/eoyc.cr"
 SNAPCRAFT_FILE = "snap/snapcraft.yaml"
+PKGBUILD_FILE  = "aur/PKGBUILD"
 
 # Extract version from shard.yml
 def get_shard_version : String?
@@ -30,6 +31,15 @@ end
 def get_snapcraft_version : String?
   snapcraft = YAML.parse(File.read(SNAPCRAFT_FILE))
   snapcraft["version"].as_s
+rescue
+  nil
+end
+
+# Extract pkgver from aur/PKGBUILD
+def get_pkgbuild_version : String?
+  content = File.read(PKGBUILD_FILE)
+  match = content.match(/^pkgver=([\d.]+)/m)
+  match ? match[1] : nil
 rescue
   nil
 end
@@ -67,6 +77,18 @@ rescue ex
   false
 end
 
+# Update aur/PKGBUILD pkgver (and reset pkgrel to 1)
+def update_pkgbuild_version(new_version : String) : Bool
+  content = File.read(PKGBUILD_FILE)
+  updated = content.gsub(/^pkgver=[\d.]+/m, "pkgver=#{new_version}")
+  updated = updated.gsub(/^pkgrel=\d+/m, "pkgrel=1")
+  File.write(PKGBUILD_FILE, updated)
+  true
+rescue ex
+  puts "  Error updating #{PKGBUILD_FILE}: #{ex.message}"
+  false
+end
+
 # Validate version format (semver-like: X.Y.Z)
 def valid_version?(version : String) : Bool
   !!(version =~ /^\d+\.\d+\.\d+$/)
@@ -81,14 +103,16 @@ puts
 shard_v = get_shard_version
 eoyc_v = get_eoyc_version
 snapcraft_v = get_snapcraft_version
+pkgbuild_v = get_pkgbuild_version
 
 puts "Current versions:"
 puts "  #{SHARD_FILE.ljust(25)} #{shard_v || "Not found"}"
 puts "  #{EOYC_FILE.ljust(25)} #{eoyc_v || "Not found"}"
 puts "  #{SNAPCRAFT_FILE.ljust(25)} #{snapcraft_v || "Not found"}"
+puts "  #{PKGBUILD_FILE.ljust(25)} #{pkgbuild_v || "Not found"}"
 puts
 
-versions = [shard_v, eoyc_v, snapcraft_v].compact
+versions = [shard_v, eoyc_v, snapcraft_v, pkgbuild_v].compact
 unique_versions = versions.uniq
 
 if unique_versions.size > 1
@@ -153,6 +177,17 @@ if snapcraft_v
   total_count += 1
   print "  Updating #{SNAPCRAFT_FILE}... "
   if update_snapcraft_version(new_version)
+    puts "✓"
+    success_count += 1
+  else
+    puts "✗"
+  end
+end
+
+if pkgbuild_v
+  total_count += 1
+  print "  Updating #{PKGBUILD_FILE}... "
+  if update_pkgbuild_version(new_version)
     puts "✓"
     success_count += 1
   else

--- a/scripts/version_update.cr
+++ b/scripts/version_update.cr
@@ -1,0 +1,169 @@
+require "yaml"
+
+# Bumps the version string in every file that embeds it, keeping them in
+# sync. Run via `just version-update` (or `crystal run
+# scripts/version_update.cr`) and enter the new version when prompted.
+
+# Version file locations
+SHARD_FILE     = "shard.yml"
+EOYC_FILE      = "src/eoyc.cr"
+SNAPCRAFT_FILE = "snap/snapcraft.yaml"
+
+# Extract version from shard.yml
+def get_shard_version : String?
+  shard = YAML.parse(File.read(SHARD_FILE))
+  shard["version"].as_s
+rescue
+  nil
+end
+
+# Extract VERSION from src/eoyc.cr
+def get_eoyc_version : String?
+  content = File.read(EOYC_FILE)
+  match = content.match(/VERSION\s*=\s*"([^"]+)"/)
+  match ? match[1] : nil
+rescue
+  nil
+end
+
+# Extract version from snap/snapcraft.yaml
+def get_snapcraft_version : String?
+  snapcraft = YAML.parse(File.read(SNAPCRAFT_FILE))
+  snapcraft["version"].as_s
+rescue
+  nil
+end
+
+# Update shard.yml version
+def update_shard_version(new_version : String) : Bool
+  content = File.read(SHARD_FILE)
+  updated = content.gsub(/^(version:\s*)[\d.]+/m, "\\1#{new_version}")
+  File.write(SHARD_FILE, updated)
+  true
+rescue ex
+  puts "  Error updating #{SHARD_FILE}: #{ex.message}"
+  false
+end
+
+# Update src/eoyc.cr VERSION
+def update_eoyc_version(new_version : String) : Bool
+  content = File.read(EOYC_FILE)
+  updated = content.gsub(/VERSION\s*=\s*"[^"]+"/, "VERSION = \"#{new_version}\"")
+  File.write(EOYC_FILE, updated)
+  true
+rescue ex
+  puts "  Error updating #{EOYC_FILE}: #{ex.message}"
+  false
+end
+
+# Update snap/snapcraft.yaml version
+def update_snapcraft_version(new_version : String) : Bool
+  content = File.read(SNAPCRAFT_FILE)
+  updated = content.gsub(/^(version:\s*)['"]?[\d.]+['"]?/m, "\\1#{new_version}")
+  File.write(SNAPCRAFT_FILE, updated)
+  true
+rescue ex
+  puts "  Error updating #{SNAPCRAFT_FILE}: #{ex.message}"
+  false
+end
+
+# Validate version format (semver-like: X.Y.Z)
+def valid_version?(version : String) : Bool
+  !!(version =~ /^\d+\.\d+\.\d+$/)
+end
+
+# Main logic
+puts "=" * 50
+puts "Eoyc Version Update Tool"
+puts "=" * 50
+puts
+
+shard_v = get_shard_version
+eoyc_v = get_eoyc_version
+snapcraft_v = get_snapcraft_version
+
+puts "Current versions:"
+puts "  #{SHARD_FILE.ljust(25)} #{shard_v || "Not found"}"
+puts "  #{EOYC_FILE.ljust(25)} #{eoyc_v || "Not found"}"
+puts "  #{SNAPCRAFT_FILE.ljust(25)} #{snapcraft_v || "Not found"}"
+puts
+
+versions = [shard_v, eoyc_v, snapcraft_v].compact
+unique_versions = versions.uniq
+
+if unique_versions.size > 1
+  puts "⚠️  Warning: Versions do not match!"
+  puts "   Unique versions found: #{unique_versions.join(", ")}"
+  puts
+end
+
+current_version = shard_v || eoyc_v || snapcraft_v || "unknown"
+puts "Current version: #{current_version}"
+puts
+
+print "Enter new version (or press Enter to cancel): "
+input = gets
+new_version = input.try(&.strip) || ""
+
+if new_version.empty?
+  puts "Cancelled."
+  exit 0
+end
+
+unless valid_version?(new_version)
+  puts "❌ Invalid version format. Please use semantic versioning (e.g., 1.2.3)"
+  exit 1
+end
+
+if new_version == current_version
+  puts "⚠️  New version is the same as current version. No changes made."
+  exit 0
+end
+
+puts
+puts "Updating to version #{new_version}..."
+puts
+
+success_count = 0
+total_count = 0
+
+if shard_v
+  total_count += 1
+  print "  Updating #{SHARD_FILE}... "
+  if update_shard_version(new_version)
+    puts "✓"
+    success_count += 1
+  else
+    puts "✗"
+  end
+end
+
+if eoyc_v
+  total_count += 1
+  print "  Updating #{EOYC_FILE}... "
+  if update_eoyc_version(new_version)
+    puts "✓"
+    success_count += 1
+  else
+    puts "✗"
+  end
+end
+
+if snapcraft_v
+  total_count += 1
+  print "  Updating #{SNAPCRAFT_FILE}... "
+  if update_snapcraft_version(new_version)
+    puts "✓"
+    success_count += 1
+  else
+    puts "✗"
+  end
+end
+
+puts
+if success_count == total_count
+  puts "✅ All #{success_count} files updated successfully to version #{new_version}"
+else
+  puts "⚠️  Updated #{success_count}/#{total_count} files"
+  exit 1
+end

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: eoyc
 base: core24
-version: 0.3.0
+version: 0.4.0
 summary: Endless Options, Your Chain
 description: |
   Endless Options, Your Chain
@@ -34,6 +34,6 @@ parts:
       - libevent-dev
       - libgmp-dev
     stage-packages:
-      - libssl1.1
+      - libssl3
       - libxml2
       - libevent-2.1-7


### PR DESCRIPTION
Mirrors the `hwaro` project's GitHub Actions setup and tightens overall project quality. Reference: `../hwaro`.

## Workflows
- **crystal.yml**: switch to `crystal-lang/install-crystal@v1` + `checkout@v6`; matrix `[1.19.0, 1.20.0]` to match `crystal: ~> 1.19` (dropped 1.15–1.18, which contradicted that requirement); add `push` + path-filtered `pull_request` triggers; run Ameba without a redundant container; add a matrixed `tests` job.
- **release-deb.yml**: build the `.deb` from the prebuilt release binary via `workflow_run` instead of a slow QEMU rebuild; add `version` / `upload_to_release` dispatch inputs; fix a copy-pasted package `Description`.
- **release-binary.yml**: `checkout@v6`, `upload-artifact@v6`, include-style matrix.
- **release-sbom.yml**: `checkout@v6`, `cyclonedx-cr@v1.0.2`.
- **publish-snapcraft.yml**: only publish on `release` events (dispatch = build only).
- **contributors.yml**: exclude bots.
- **hwaro.yml**: only run when `docs/**` changes.
- **release-aur.yml** (new): publish to AUR after a release binary build (or manual dispatch), using the env-var-safe version resolution shared by the other release workflows.

## Packaging / quality
- **snap/snapcraft.yaml**: bump `0.3.0 → 0.4.0` (was out of sync) and `libssl1.1 → libssl3` (core24 has no libssl1.1).
- **aur/PKGBUILD** (new): prebuilt-binary PKGBUILD mirroring hwaro.
- **scripts/version_check.cr** + **version_update.cr** (new): keep the version literal in sync across `shard.yml`, `src/eoyc.cr`, `snap/snapcraft.yaml`, and `aur/PKGBUILD` (resetting `pkgrel` to 1). The homebrew formula uses `__VERSION__` placeholders, so it needs no sync.
- **justfile**: project-local Ameba (no global install needed), task groups, `clean` + `version-check`/`version-update` tasks, and docs tasks fixed to use **hwaro** (the docs site is hwaro-generated, not zola).
- Added **.ameba.yml**, **.github/FUNDING.yml**, **CONTRIBUTING.md**.
- **README/AGENTS.md**: fixed stale zola / ameba / Crystal-version references.

## Verification
- `crystal spec` → 141 examples, 0 failures
- `shards build` OK (binary reports `0.4.0`)
- Ameba → 40 files, 0 failures
- `just version-check` → all 4 files match `0.4.0`
- All 9 workflow YAML files parse cleanly