### PR TITLE
Fix AUR PKGBUILD license install and support custom pkgrel/ref

### DIFF
--- a/.github/workflows/release-aur.yml
+++ b/.github/workflows/release-aur.yml
@@ -7,6 +7,15 @@ on:
         description: "Version to publish (e.g., 0.4.0)"
         required: true
         type: string
+      ref:
+        description: "Git ref (branch/tag/commit) to checkout (optional, defaults to v<version>)"
+        required: false
+        type: string
+      pkgrel:
+        description: "Package release version (pkgrel) (optional, defaults to 1)"
+        required: false
+        default: "1"
+        type: string
   workflow_run:
     workflows: ["Build and Release Binaries"]
     types: [completed]
@@ -25,7 +34,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.inputs.ref || (github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.version) || github.event.workflow_run.head_branch) }}
 
       - name: Get Version
         id: get_version
@@ -49,9 +58,10 @@ jobs:
       - name: Update PKGBUILD version
         env:
           V: ${{ env.VERSION }}
+          PKGREL: ${{ github.event.inputs.pkgrel || '1' }}
         run: |
           sed -i "s/^pkgver=.*/pkgver=${V}/" aur/PKGBUILD
-          sed -i "s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=${PKGREL}/" aur/PKGBUILD
           cat aur/PKGBUILD
 
       - name: Publish to AUR

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -6,10 +6,16 @@ pkgdesc="Endless Options, Your Chain - chainable string encoding/decoding CLI wr
 arch=('x86_64')
 url="https://github.com/hahwul/eoyc"
 license=('MIT')
-source=("eoyc-${pkgver}::https://github.com/hahwul/eoyc/releases/download/v${pkgver}/eoyc-v${pkgver}-linux-x86_64")
-sha256sums=('SKIP')
+source=(
+  "eoyc-${pkgver}::https://github.com/hahwul/eoyc/releases/download/v${pkgver}/eoyc-v${pkgver}-linux-x86_64"
+  "LICENSE-eoyc-${pkgver}::https://raw.githubusercontent.com/hahwul/eoyc/refs/tags/v${pkgver}/LICENSE"
+)
+sha256sums=(
+  'SKIP'
+  'SKIP'
+)
 
 package() {
   install -Dm755 "${srcdir}/eoyc-${pkgver}" "${pkgdir}/usr/bin/eoyc"
-  install -Dm644 "${srcdir}/../LICENSE" "${pkgdir}/usr/share/licenses/eoyc/LICENSE"
+  install -Dm644 "${srcdir}/LICENSE-eoyc-${pkgver}" "${pkgdir}/usr/share/licenses/eoyc/LICENSE"
 }


### PR DESCRIPTION
## Problem
The AUR `package()` step installed the license from `${srcdir}/../LICENSE`, a path that does **not** exist on a clean AUR build. The `KSXGitHub/github-actions-deploy-aur` action only pushes `PKGBUILD` (+ generated `.SRCINFO`) to the AUR repo — not the `LICENSE` file — so `makepkg` fails when it cannot find `../LICENSE`.

Same class of bug fixed upstream in noir ([owasp-noir/noir@3f216a4](https://github.com/owasp-noir/noir/commit/3f216a42240e15e5e6195243a6b7de3c5f28e040)), reported via the AUR `noir` package.

## Fix
- Download `LICENSE` through the `source=()` array from the tagged raw URL and install it from `${srcdir}`.
- Add optional `ref` and `pkgrel` `workflow_dispatch` inputs to `release-aur.yml` so a packaging-only fix can be republished to AUR with a bumped `pkgrel` (pointing at an existing release tag) without cutting a new upstream release.