### PR TITLE
style: remove redundant begin blocks in encoders

### DIFF
--- a/src/encoders/base64.cr
+++ b/src/encoders/base64.cr
@@ -22,11 +22,9 @@ Encoders.register(
     category: "encoding",
     flags: %w[decode reversible]
   ) do |str|
-    begin
-      Base64.decode_string(str)
-    rescue
-      str
-    end
+    Base64.decode_string(str)
+  rescue
+    str
   end
 )
 

--- a/src/encoders/compression.cr
+++ b/src/encoders/compression.cr
@@ -11,15 +11,13 @@ Encoders.register(
     category: "compression",
     flags: %w[encode reversible compression]
   ) do |str|
-    begin
-      compressed = IO::Memory.new
-      Compress::Zlib::Writer.open(compressed) do |zlib|
-        zlib.print(str)
-      end
-      Base64.strict_encode(compressed.to_slice)
-    rescue
-      str
+    compressed = IO::Memory.new
+    Compress::Zlib::Writer.open(compressed) do |zlib|
+      zlib.print(str)
     end
+    Base64.strict_encode(compressed.to_slice)
+  rescue
+    str
   end
 )
 
@@ -32,15 +30,13 @@ Encoders.register(
     category: "compression",
     flags: %w[decode reversible compression]
   ) do |str|
-    begin
-      decoded = Base64.decode(str)
-      input = IO::Memory.new(decoded)
-      Compress::Zlib::Reader.open(input) do |zlib|
-        zlib.gets_to_end
-      end
-    rescue
-      str
+    decoded = Base64.decode(str)
+    input = IO::Memory.new(decoded)
+    Compress::Zlib::Reader.open(input) do |zlib|
+      zlib.gets_to_end
     end
+  rescue
+    str
   end
 )
 
@@ -53,15 +49,13 @@ Encoders.register(
     category: "compression",
     flags: %w[encode reversible compression]
   ) do |str|
-    begin
-      compressed = IO::Memory.new
-      Compress::Gzip::Writer.open(compressed) do |gzip|
-        gzip.print(str)
-      end
-      Base64.strict_encode(compressed.to_slice)
-    rescue
-      str
+    compressed = IO::Memory.new
+    Compress::Gzip::Writer.open(compressed) do |gzip|
+      gzip.print(str)
     end
+    Base64.strict_encode(compressed.to_slice)
+  rescue
+    str
   end
 )
 
@@ -74,14 +68,12 @@ Encoders.register(
     category: "compression",
     flags: %w[decode reversible compression]
   ) do |str|
-    begin
-      decoded = Base64.decode(str)
-      input = IO::Memory.new(decoded)
-      Compress::Gzip::Reader.open(input) do |gzip|
-        gzip.gets_to_end
-      end
-    rescue
-      str
+    decoded = Base64.decode(str)
+    input = IO::Memory.new(decoded)
+    Compress::Gzip::Reader.open(input) do |gzip|
+      gzip.gets_to_end
     end
+  rescue
+    str
   end
 )

--- a/src/encoders/digests.cr
+++ b/src/encoders/digests.cr
@@ -15,11 +15,9 @@ Encoders.register(
     category: "hash",
     flags: %w[one-way digest]
   ) do |str|
-    begin
-      Digest::MD5.hexdigest(str)
-    rescue
-      str
-    end
+    Digest::MD5.hexdigest(str)
+  rescue
+    str
   end
 )
 
@@ -32,11 +30,9 @@ Encoders.register(
     category: "hash",
     flags: %w[one-way digest]
   ) do |str|
-    begin
-      Digest::SHA1.base64digest(str)
-    rescue
-      str
-    end
+    Digest::SHA1.base64digest(str)
+  rescue
+    str
   end
 )
 
@@ -49,11 +45,9 @@ Encoders.register(
     category: "hash",
     flags: %w[one-way digest]
   ) do |str|
-    begin
-      Digest::SHA1.hexdigest(str)
-    rescue
-      str
-    end
+    Digest::SHA1.hexdigest(str)
+  rescue
+    str
   end
 )
 
@@ -66,11 +60,9 @@ Encoders.register(
     category: "hash",
     flags: %w[one-way digest]
   ) do |str|
-    begin
-      Digest::SHA256.base64digest(str)
-    rescue
-      str
-    end
+    Digest::SHA256.base64digest(str)
+  rescue
+    str
   end
 )
 
@@ -83,11 +75,9 @@ Encoders.register(
     category: "hash",
     flags: %w[one-way digest]
   ) do |str|
-    begin
-      Digest::SHA256.hexdigest(str)
-    rescue
-      str
-    end
+    Digest::SHA256.hexdigest(str)
+  rescue
+    str
   end
 )
 
@@ -100,11 +90,9 @@ Encoders.register(
     category: "hash",
     flags: %w[one-way digest]
   ) do |str|
-    begin
-      Digest::SHA512.base64digest(str)
-    rescue
-      str
-    end
+    Digest::SHA512.base64digest(str)
+  rescue
+    str
   end
 )
 
@@ -117,11 +105,9 @@ Encoders.register(
     category: "hash",
     flags: %w[one-way digest]
   ) do |str|
-    begin
-      Digest::SHA512.hexdigest(str)
-    rescue
-      str
-    end
+    Digest::SHA512.hexdigest(str)
+  rescue
+    str
   end
 )
 
@@ -134,13 +120,11 @@ Encoders.register(
     category: "hash",
     flags: %w[one-way digest]
   ) do |str|
-    begin
-      digest = OpenSSL::Digest.new("SHA384")
-      digest.update(str)
-      Base64.strict_encode(digest.final)
-    rescue
-      str
-    end
+    digest = OpenSSL::Digest.new("SHA384")
+    digest.update(str)
+    Base64.strict_encode(digest.final)
+  rescue
+    str
   end
 )
 
@@ -153,12 +137,10 @@ Encoders.register(
     category: "hash",
     flags: %w[one-way digest]
   ) do |str|
-    begin
-      digest = OpenSSL::Digest.new("SHA384")
-      digest.update(str)
-      digest.final.map(&.to_s(16).rjust(2, '0')).join
-    rescue
-      str
-    end
+    digest = OpenSSL::Digest.new("SHA384")
+    digest.update(str)
+    digest.final.map(&.to_s(16).rjust(2, '0')).join
+  rescue
+    str
   end
 )

--- a/src/encoders/url_form.cr
+++ b/src/encoders/url_form.cr
@@ -10,11 +10,9 @@ Encoders.register(
     category: "encoding",
     flags: %w[encode reversible web]
   ) do |str|
-    begin
-      URI.encode_www_form(str)
-    rescue
-      str
-    end
+    URI.encode_www_form(str)
+  rescue
+    str
   end
 )
 
@@ -27,10 +25,8 @@ Encoders.register(
     category: "encoding",
     flags: %w[decode reversible web]
   ) do |str|
-    begin
-      URI.decode_www_form(str)
-    rescue
-      str
-    end
+    URI.decode_www_form(str)
+  rescue
+    str
   end
 )


### PR DESCRIPTION
Removes redundant begin blocks within blocks in encoders. This resolves the lint failures reported in CI.