### PR TITLE
fix(release): bundle Homebrew dylibs in macOS release tarballs

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -53,33 +53,19 @@ jobs:
             /usr/bin/crystal build src/eoyc.cr -o build/eoyc-${GITHUB_REF_SLUG}-linux-${ARCH} --release --no-debug --static
           "
       - if: matrix.platform == 'macos'
-        name: Build binary (macOS)
+        name: Install macOS build dependencies
+        run: brew install openssl@3 pkg-config
+      - if: matrix.platform == 'macos'
+        name: Build and package binary (macOS)
         run: |
           mkdir -p build
-          # Pin PKG_CONFIG_PATH to openssl@3 so the binary links the current
-          # OpenSSL instead of an EOL openssl@1.1, which would fail to launch on
-          # a clean machine (dyld: libssl.1.1.dylib not found). openssl@3 is the
-          # only Homebrew dylib the binary needs; it is declared in the formula.
-          brew install openssl@3
-          export PKG_CONFIG_PATH="$(brew --prefix openssl@3)/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+          OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+          export PKG_CONFIG_PATH="${OPENSSL_PREFIX}/lib/pkgconfig"
           BIN="build/eoyc-${GITHUB_REF_SLUG}-osx-${ARCH}"
-          crystal build src/eoyc.cr \
-            -o "$BIN" \
-            --no-debug --release
-          echo "== otool -L $BIN ==" && otool -L "$BIN"
-          # Guard 1: never ship a macOS binary linked against EOL openssl@1.1.
-          if otool -L "$BIN" | grep -q 'openssl@1.1'; then
-            echo "::error::macOS binary still links EOL openssl@1.1"; exit 1
-          fi
-          # Guard 2: openssl@3 must be the ONLY Homebrew dynamic dep, else the
-          # formula's depends_on list is out of date.
-          EXTRA="$(otool -L "$BIN" \
-            | grep -oE '/(opt/homebrew|usr/local)/(opt|Cellar)/[^/]+' \
-            | grep -v 'openssl@3' | sort -u || true)"
-          if [ -n "$EXTRA" ]; then
-            echo "::error::unexpected non-openssl@3 Homebrew deps (update formula depends_on):"
-            echo "$EXTRA"; exit 1
-          fi
+          crystal build src/eoyc.cr -o "$BIN" --no-debug --release
+          chmod +x scripts/package-macos.sh
+          scripts/package-macos.sh "$BIN" "build/eoyc-${GITHUB_REF_SLUG}-osx-${ARCH}.tar.gz" eoyc
+          rm -f "$BIN"
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Bundle Homebrew-linked dylibs next to a Crystal macOS binary so the
+# release tarball runs without a local OpenSSL (or other brew) install.
+#
+# Usage: scripts/package-macos.sh <binary-path> <output-tarball> [staged-name]
+#
+# Archive layout:
+#   <staged-name>
+#   lib/*.dylib
+set -euo pipefail
+
+BINARY="${1:?Usage: $0 <binary-path> <output-tarball> [staged-name]}"
+OUTPUT="${2:?Usage: $0 <binary-path> <output-tarball> [staged-name]}"
+NAME="${3:-$(basename "$BINARY")}"
+
+if [[ ! -f "$BINARY" ]]; then
+  echo "error: binary not found: $BINARY" >&2
+  exit 1
+fi
+
+if ! command -v otool >/dev/null 2>&1 || ! command -v install_name_tool >/dev/null 2>&1; then
+  echo "error: otool and install_name_tool are required (macOS only)" >&2
+  exit 1
+fi
+
+STAGING="$(mktemp -d)"
+trap 'rm -rf "$STAGING"' EXIT
+
+mkdir -p "$STAGING/lib"
+cp "$BINARY" "$STAGING/$NAME"
+chmod +x "$STAGING/$NAME"
+
+BREW_PREFIX_RE='^(/opt/homebrew|/usr/local)/'
+
+homebrew_deps() {
+  local target="$1"
+  otool -L "$target" | awk 'NR>1 {print $1}' | grep -E "$BREW_PREFIX_RE" || true
+}
+
+DEPS_FILE="$STAGING/deps.txt"
+: > "$DEPS_FILE"
+
+while true; do
+  added=0
+  for target in "$STAGING/$NAME" "$STAGING"/lib/*.dylib; do
+    [[ -e "$target" ]] || continue
+    while IFS= read -r dep; do
+      [[ -z "$dep" ]] && continue
+      base="$(basename "$dep")"
+      if ! grep -Fxq "$dep" "$DEPS_FILE"; then
+        echo "$dep" >> "$DEPS_FILE"
+      fi
+      if [[ ! -f "$STAGING/lib/$base" ]]; then
+        cp "$dep" "$STAGING/lib/$base"
+        added=1
+      fi
+    done < <(homebrew_deps "$target")
+  done
+  [[ "$added" -eq 0 ]] && break
+done
+
+rewrite_paths() {
+  local target="$1"
+  while IFS= read -r dep; do
+    [[ -z "$dep" ]] && continue
+    install_name_tool -change "$dep" "@executable_path/lib/$(basename "$dep")" "$target"
+  done < "$DEPS_FILE"
+}
+
+rewrite_paths "$STAGING/$NAME"
+for lib in "$STAGING"/lib/*.dylib; do
+  [[ -e "$lib" ]] || continue
+  install_name_tool -id "@executable_path/lib/$(basename "$lib")" "$lib"
+  rewrite_paths "$lib"
+done
+
+if otool -L "$STAGING/$NAME" | awk 'NR>1 {print $1}' | grep -Eq "$BREW_PREFIX_RE"; then
+  echo "error: Homebrew paths remain after bundling:" >&2
+  otool -L "$STAGING/$NAME" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+tar -czf "$OUTPUT" -C "$STAGING" "$NAME" lib
+
+echo "Created $OUTPUT"
+if "$STAGING/$NAME" --version >/dev/null 2>&1; then
+  "$STAGING/$NAME" --version
+fi


### PR DESCRIPTION
## Summary

Bundle Homebrew-linked dylibs in macOS release tarballs so direct-download binaries run without a local OpenSSL install.

Previous releases linked openssl@1.1 and failed on clean macOS installs.

## Changes

- Add `scripts/package-macos.sh`
- Update release workflow to build against `openssl@3`, package binary + `lib/` as `.tar.gz`

## Breaking change

macOS release assets change from a bare executable to a `.tar.gz` archive. Extract and keep `lib/` next to the binary.